### PR TITLE
add self.miter_plane

### DIFF
--- a/src/compas_timber/connections/k_birdsmouth.py
+++ b/src/compas_timber/connections/k_birdsmouth.py
@@ -1,6 +1,7 @@
 from compas.geometry import Plane
 from compas.geometry import Point
 from compas.geometry import Vector
+from compas.geometry import Frame
 from compas.geometry import cross_vectors
 
 from compas_timber.errors import BeamJoiningError
@@ -120,29 +121,20 @@ class KBirdsmouthJoint(Joint):
         return all_cutting_planes
 
     def _get_miter_planes(self):
-        # default bisector miter plane
-        vA = Vector(*self.main_beam_a.frame.xaxis)  # frame.axis gives a reference, not a copy
-        vB = Vector(*self.main_beam_b.frame.xaxis)
-        # intersection point (average) of both centrelines
-        try:
-            p = self.location
-        except ValueError:
-            p = None
+        # intersection point (average) of two main beam centrelines
+        [pxA, tA], [pxB, tB] = intersection_line_line_param(
+            self.main_beam_a.centerline,
+            self.main_beam_b.centerline,
+            max_distance=float("inf"),
+            limit_to_segments=False,
+        )
+        # TODO: add error-trap + solution for I-miter joints
 
-        if not p:
-            [pxA, tA], [pxB, tB] = intersection_line_line_param(
-                self.main_beam_a.centerline,
-                self.main_beam_b.centerline,
-                max_distance=float("inf"),
-                limit_to_segments=False,
-            )
-            # TODO: add error-trap + solution for I-miter joints
+        p = Point((pxA.x + pxB.x) * 0.5, (pxA.y + pxB.y) * 0.5, (pxA.z + pxB.z) * 0.5)
 
-            p = Point((pxA.x + pxB.x) * 0.5, (pxA.y + pxB.y) * 0.5, (pxA.z + pxB.z) * 0.5)
-
-        # makes sure they point outward of a joint point
-        vA = self.point_centerline_towards_joint(self.main_beam_a, p)
-        vB = self.point_centerline_towards_joint(self.main_beam_b, p)
+        # makes sure they point outward of a joint point, and are unitized
+        vA = self.point_centerline_towards_joint(self.main_beam_a, p).unitized()
+        vB = self.point_centerline_towards_joint(self.main_beam_b, p).unitized()
 
         # bisector
         v_bisector = vA + vB

--- a/src/compas_timber/connections/k_birdsmouth.py
+++ b/src/compas_timber/connections/k_birdsmouth.py
@@ -50,6 +50,7 @@ class KBirdsmouthJoint(Joint):
     def __data__(self):
         data = super(KBirdsmouthJoint, self).__data__
         data["mill_depth"] = self.mill_depth
+        data["miter_plane"] = self.miter_plane
         return data
 
     def __init__(self, cross_beam=None, main_beam_a=None, main_beam_b=None, mill_depth=None, miter_plane=None, **kwargs):

--- a/src/compas_timber/connections/k_birdsmouth.py
+++ b/src/compas_timber/connections/k_birdsmouth.py
@@ -51,9 +51,10 @@ class KBirdsmouthJoint(Joint):
         data["mill_depth"] = self.mill_depth
         return data
 
-    def __init__(self, cross_beam=None, main_beam_a=None, main_beam_b=None, mill_depth=None, **kwargs):
+    def __init__(self, cross_beam=None, main_beam_a=None, main_beam_b=None, mill_depth=None, miter_plane=None, **kwargs):
         super(KBirdsmouthJoint, self).__init__(elements=(cross_beam, main_beam_a, main_beam_b), **kwargs)
         self.mill_depth = mill_depth
+        self.miter_plane = miter_plane
         self.features = []  # TODO: remove?
 
     @property
@@ -170,7 +171,12 @@ class KBirdsmouthJoint(Joint):
         assert self.main_beams and self.cross_beam
         for beam in self.main_beams:
             start_a, end_a = None, None
-            miter_plane = self._get_miter_planes()[0]
+
+            if self.miter_plane is None:
+                miter_plane = self._get_miter_planes()[0]
+            else:
+                miter_plane = self.miter_plane
+            # miter_plane = self._get_miter_planes()[0]
             try:
                 start_a, end_a = beam.extension_to_plane(miter_plane)
             except Exception as ex:
@@ -198,7 +204,12 @@ class KBirdsmouthJoint(Joint):
             self.features.append(main_feature)
 
         # generate miter cut features for each main beam
-        miter_planes = self._get_miter_planes()
+        # miter_planes = self._get_miter_planes()
+        if self.miter_plane is None:
+            miter_planes = self._get_miter_planes()
+        else:
+            miter_planes = self.miter_plane, Plane(self.miter_plane.point, self.miter_plane.normal * -1.0)
+            
         for main_beam, miter_plane in zip(self.main_beams, miter_planes):
             miter_feature = JackRafterCut.from_plane_and_beam(miter_plane, main_beam)
             main_beam.add_features(miter_feature)

--- a/src/compas_timber/connections/k_birdsmouth.py
+++ b/src/compas_timber/connections/k_birdsmouth.py
@@ -168,7 +168,7 @@ class KBirdsmouthJoint(Joint):
                 miter_plane = self._get_miter_planes()[0]
             else:
                 miter_plane = self.miter_plane
-            # miter_plane = self._get_miter_planes()[0]
+
             try:
                 start_a, end_a = beam.extension_to_plane(miter_plane)
             except Exception as ex:
@@ -196,7 +196,6 @@ class KBirdsmouthJoint(Joint):
             self.features.append(main_feature)
 
         # generate miter cut features for each main beam
-        # miter_planes = self._get_miter_planes()
         if self.miter_plane is None:
             miter_planes = self._get_miter_planes()
         else:


### PR DESCRIPTION
Add miter_plane argument, allowing a user-defined miter_plane for KBirdsmouthJoint.
Warning: _get_miter_planes method does not generate the correct average bisector.

<!-- Thank you for your pull request!  -->
<!-- Please start by describing your change in a few sentences. -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation, including updating `class_diagrams.rst` (if appropriate).
